### PR TITLE
[MOO-1633] Prevent Font Scale Crashing

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,7 +74,7 @@
             android:supportsRtl="true">
         <activity
                 android:name=".MainActivity"
-                android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+                android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode|fontScale"
                 android:launchMode="singleTask"
                 android:screenOrientation="user"
                 android:windowSoftInputMode="stateHidden"

--- a/android/app/src/production/AndroidManifest.xml
+++ b/android/app/src/production/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode|fontScale"
             android:launchMode="singleTask"
             android:screenOrientation="user"
             android:windowSoftInputMode="stateHidden"


### PR DESCRIPTION
Adding "fontScale" to `configChanges` in AndroidManifest.xml prevents crashings
- `fontScale` – Prevents recreation when the system font scale is changed.



