### PR TITLE
update native binary version and @mendix/native for Mx 10.22

### DIFF
--- a/ios/DeveloperApp/Info.plist
+++ b/ios/DeveloperApp/Info.plist
@@ -86,7 +86,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>To use that feature the app needs access to your photo library.</string>
 	<key>Native Binary Version</key>
-	<integer>10</integer>
+	<integer>14</integer>
 	<key>NativeOTAEnabled</key>
 	<true/>
 	<key>ReferenceGuideUrl</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@babylonjs/react-native": "1.6.3",
         "@babylonjs/react-native-iosandroid-0-71": "1.6.3",
         "@gorhom/bottom-sheet": "^5.1.1",
-        "@mendix/native": "9.0.3",
+        "@mendix/native": "9.0.4",
         "@op-engineering/op-sqlite": "9.2.7",
         "@react-native-async-storage/async-storage": "2.0.0",
         "@react-native-camera-roll/camera-roll": "7.4.0",
@@ -2094,9 +2094,9 @@
       }
     },
     "node_modules/@mendix/native": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@mendix/native/-/native-9.0.3.tgz",
-      "integrity": "sha512-0dWVWeHgXhEsOYQ72MJAr1bmAnOZlFisJbfzPx9N/9Ml0Sb9Cnf0utKLtyhyQV803+mJoEFkf6eH+FazrpRJSQ=="
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@mendix/native/-/native-9.0.4.tgz",
+      "integrity": "sha512-4WQZiRR1l1Mggpue7EOs2vQL6DyDmmVzcTzaMMrqzIF9GyqocrXjOqYGthlcQpF8k9/rQPgDojntrxGApjPWUA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -11062,9 +11062,9 @@
       }
     },
     "@mendix/native": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@mendix/native/-/native-9.0.3.tgz",
-      "integrity": "sha512-0dWVWeHgXhEsOYQ72MJAr1bmAnOZlFisJbfzPx9N/9Ml0Sb9Cnf0utKLtyhyQV803+mJoEFkf6eH+FazrpRJSQ=="
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@mendix/native/-/native-9.0.4.tgz",
+      "integrity": "sha512-4WQZiRR1l1Mggpue7EOs2vQL6DyDmmVzcTzaMMrqzIF9GyqocrXjOqYGthlcQpF8k9/rQPgDojntrxGApjPWUA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babylonjs/loaders": "6.8.1",
     "@babylonjs/react-native": "1.6.3",
     "@babylonjs/react-native-iosandroid-0-71": "1.6.3",
-    "@mendix/native": "9.0.3",
+    "@mendix/native": "9.0.4",
     "@op-engineering/op-sqlite": "9.2.7",
     "@gorhom/bottom-sheet": "^5.1.1",
     "@react-native-async-storage/async-storage": "2.0.0",


### PR DESCRIPTION
### **CAUTION!!!:** 

This PR Targets mx/10.22 but it is meant to be used with Mendix Studio Pro 10.24 (unreleased)!!! Merge accordingly