### PR TITLE
Off/705 cookie encryption 10.24

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,6 +41,7 @@ android {
         buildConfigField "boolean", "DETOX", "false"
         buildConfigField "String", "RUNTIME_URL", '""'
         buildConfigField "boolean", "OTA", "false"
+        manifestPlaceholders["cookieEncryption"] = project.hasProperty("mendixnative.cookieEncryption") ? project.property("mendixnative.cookieEncryption") : "false"
     }
     signingConfigs {
         debug {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -118,6 +118,8 @@
         </service>
         <meta-data android:name="com.google.android.geo.API_KEY"
                    android:value="{{GEO_API_KEY}}"/>
+        <meta-data android:name="mendixnative.CookieEncryption"
+                   android:value="${cookieEncryption}"/>
         <meta-data
                 android:name="com.google.ar.core"
                 android:value="optional"/>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -26,3 +26,4 @@ android.nonTransitiveRClass=true
 # enabled by default in RN 0.76 so we need to disable it explicitly
 newArchEnabled=false
 hermesEnabled=true
+mendixnative.cookieEncryption=true


### PR DESCRIPTION
This doesn't need a new store release just for this. It can wait for the next release, this is not that important.