### PR TITLE
[MOO-2286] : Release script fixes for Docs and changelog-MiN-11-12

### DIFF
--- a/.github/workflows/release-make-it-native.yml
+++ b/.github/workflows/release-make-it-native.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Sync docs fork with upstream
+        run: gh repo sync MendixMobile/docs --branch development --force
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release-make-it-native.yml
+++ b/.github/workflows/release-make-it-native.yml
@@ -35,3 +35,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PAT: ${{ secrets.MENDIX_MOBILE_DOCS_PR_GITHUB_PAT }}
         run: node scripts/release-make-it-native.mjs
+
+      - name: Send success message
+        if: success()
+        uses: ./.github/actions/slack-notification
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          message: |
+            ✅ *Make It Native automation succeeded!*
+            PRs created in:
+            • *make-it-native*
+            • *mendix/docs*
+            Please review and merge. 🙌
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Send failure message
+        if: failure()
+        uses: ./.github/actions/slack-notification
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          message: |
+            ❌ *Make It Native automation failed!*
+            Please check the workflow logs for more details. 🛠
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-make-it-native.yml
+++ b/.github/workflows/release-make-it-native.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PAT: ${{ secrets.PAT }}
+      PAT: ${{ secrets.MENDIX_MOBILE_DOCS_PR_GITHUB_PAT }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
@@ -24,7 +24,7 @@ jobs:
       - name: Sync docs fork with upstream
         run: gh repo sync MendixMobile/docs --branch development --force
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.MENDIX_MOBILE_DOCS_PR_GITHUB_PAT }}
 
       - name: Install dependencies
         run: npm ci
@@ -33,5 +33,5 @@ jobs:
         env:
           MIN_VERSION: ${{ github.event.inputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.MENDIX_MOBILE_DOCS_PR_GITHUB_PAT }}
         run: node scripts/release-make-it-native.mjs

--- a/.github/workflows/release-make-it-native.yml
+++ b/.github/workflows/release-make-it-native.yml
@@ -30,26 +30,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PAT: ${{ secrets.PAT }}
         run: node scripts/release-make-it-native.mjs
-
-      - name: Send success message
-        if: success()
-        uses: ./.github/actions/slack-notification
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          message: |
-            ✅ *Make It Native automation succeeded!*
-            PRs created in:
-            • *make-it-native*
-            • *mendix/docs*
-            Please review and merge. 🙌
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-
-      - name: Send failure message
-        if: failure()
-        uses: ./.github/actions/slack-notification
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          message: |
-            ❌ *Make It Native automation failed!*
-            Please check the workflow logs for more details. 🛠
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/scripts/release-make-it-native.mjs
+++ b/scripts/release-make-it-native.mjs
@@ -81,7 +81,10 @@ async function createPRUpdateChangelog() {
   await git.addConfig("user.email", GIT_AUTHOR_EMAIL, ["--global"]);
   
   // Get the current branch name (the one selected in GitHub Actions UI)
-  const currentBranch = await git.revparse(["--abbrev-ref", "HEAD"]);
+  const currentBranch = process.env.GITHUB_REF_NAME;
+  if (!currentBranch) {
+    throw new Error("GITHUB_REF_NAME environment variable is not set");
+  }
 
   await git.checkoutLocalBranch(CHANGELOG_BRANCH_NAME);
 
@@ -89,15 +92,54 @@ async function createPRUpdateChangelog() {
   await git.commit(`chore: update CHANGELOG for v${MIN_VERSION}`);
   await git.push("origin", CHANGELOG_BRANCH_NAME, ["--force-with-lease"]);
 
-  await octokit.pulls.create({
-    owner: process.env.GITHUB_REPOSITORY_OWNER,
-    repo: process.env.GITHUB_REPOSITORY.split("/")[1],
-    title: `Update CHANGELOG for v${MIN_VERSION}`,
-    head: CHANGELOG_BRANCH_NAME,
-    base: currentBranch,
-    body: "**Note:** Please do not take any action on this pull request unless it has been reviewed and approved by a member of the Mobile team.",
-    draft: true,
-  });
+  const owner = process.env.GITHUB_REPOSITORY_OWNER;
+  const repo = process.env.GITHUB_REPOSITORY.split("/")[1];
+  const prBody = "**Note:** Please do not take any action on this pull request unless it has been reviewed and approved by a member of the Mobile team.";
+
+  try {
+    await octokit.pulls.create({
+      owner,
+      repo,
+      title: `Update CHANGELOG for v${MIN_VERSION}`,
+      head: CHANGELOG_BRANCH_NAME,
+      base: currentBranch,
+      body: prBody,
+      draft: true,
+    });
+    console.log("✅ Created PR to update CHANGELOG in make-it-native");
+  } catch (err) {
+    const isPRExistsError =
+      err.status === 422 &&
+      (err.message?.includes("A pull request already exists") ||
+        err.response?.data?.errors?.some(
+          (e) => e.resource === "PullRequest" && e.message?.includes("A pull request already exists")
+        ));
+
+    if (isPRExistsError) {
+      console.log("ℹ️ PR already exists, updating existing PR...");
+      const { data: existingPRs } = await octokit.pulls.list({
+        owner,
+        repo,
+        head: CHANGELOG_BRANCH_NAME,
+        base: currentBranch,
+        state: "open",
+      });
+      if (existingPRs.length > 0) {
+        const existingPR = existingPRs[0];
+        await octokit.pulls.update({
+          owner,
+          repo,
+          pull_number: existingPR.number,
+          body: prBody,
+        });
+        console.log(`✅ Updated existing PR #${existingPR.number}`);
+      } else {
+        throw new Error("PR exists but could not be found for update");
+      }
+    } else {
+      throw err;
+    }
+  }
 }
 
 // Docs

--- a/scripts/release-make-it-native.mjs
+++ b/scripts/release-make-it-native.mjs
@@ -79,6 +79,9 @@ async function createPRUpdateChangelog() {
 
   await git.addConfig("user.name", GIT_AUTHOR_NAME, ["--global"]);
   await git.addConfig("user.email", GIT_AUTHOR_EMAIL, ["--global"]);
+  
+  // Get the current branch name (the one selected in GitHub Actions UI)
+  const currentBranch = await git.revparse(["--abbrev-ref", "HEAD"]);
 
   await git.checkoutLocalBranch(CHANGELOG_BRANCH_NAME);
 
@@ -91,7 +94,7 @@ async function createPRUpdateChangelog() {
     repo: process.env.GITHUB_REPOSITORY.split("/")[1],
     title: `Update CHANGELOG for v${MIN_VERSION}`,
     head: CHANGELOG_BRANCH_NAME,
-    base: "main",
+    base: currentBranch,
     body: "**Note:** Please do not take any action on this pull request unless it has been reviewed and approved by a member of the Mobile team.",
     draft: true,
   });
@@ -121,9 +124,6 @@ function injectUnreleasedToDoc(docPath, unreleasedContent) {
   return `${frontmatter}\n\n${firstParagraph}\n${title}\n\n${unreleasedContent}\n\n${afterFirstParagraph}`;
 }
 
-// This file exists only in the fork (MendixMobile/docs) and not in upstream (mendix/docs).
-// Removing it in our branch ensures it doesn't appear in the cross-fork PR diff.
-const FORK_SYNC_FILE = ".github/workflows/sync.yml";
 
 async function cloneDocsRepo() {
   const git = simpleGit();
@@ -148,10 +148,6 @@ async function updateDocsMiNReleaseNotes(unreleasedContent) {
 }
 
 async function createPRUpdateDocsMiNReleaseNotes(git) {
-  // Remove the fork's sync.yml so it doesn't appear in the cross-fork PR diff.
-  if (fs.existsSync(FORK_SYNC_FILE)) {
-    await git.rm(FORK_SYNC_FILE);
-  }
   await git.add(TARGET_FILE);
   await git.commit(`docs: update mobile release notes for v${MIN_VERSION}`);
   await git.push("origin", DOCS_BRANCH_NAME, ["--force"]);


### PR DESCRIPTION
In this PR -
- removed previous sync file removal logic
- Added sync logic to sync the mendixmobile/docs fork with upstream
- Added new secret - MENDIX_MOBILE_DOCS_PR_GITHUB_PAT  in MiN repo and used it in the script which has more access
- Added the logic to raise changelog PR against the correct base branch from which MiN is released and not always the main branch 