### PR TITLE
[MOO-2458]: Update Android SDK to 36

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         // needed by camera module
         googlePlayServicesVersion = "17+"
         androidXAnnotation = "1.2.0"


### PR DESCRIPTION
Update android buildtools, compile and target SDK version to 36, to be compatible with Google's Play Store policies.